### PR TITLE
Add assertions to Task, Storage and Parser classes

### DIFF
--- a/src/main/java/bugsbunny/parsers/Parser.java
+++ b/src/main/java/bugsbunny/parsers/Parser.java
@@ -34,9 +34,7 @@ public class Parser {
      * @throws BugsBunnyException If the input is malformed or uses unknown commands.
      */
     public static Command parse(String input) throws BugsBunnyException {
-        if (input == null) {
-            return new ExitCommand(); // null input shouldn't happen
-        }
+        assert input != null : "Input should not be null";
 
         if (input.isEmpty()) {
             throw new BugsBunnyException("Your input cannot be empty");

--- a/src/main/java/bugsbunny/storage/Storage.java
+++ b/src/main/java/bugsbunny/storage/Storage.java
@@ -76,6 +76,7 @@ public class Storage {
      * @throws IOException If writing fails.
      */
     public void save(TaskList taskList) throws IOException {
+        assert taskList != null : "TaskList to save should not be null";
         FileWriter fw = new FileWriter(this.filePathString);
         ArrayList<Task> list = taskList.getList();
 

--- a/src/main/java/bugsbunny/tasks/Deadline.java
+++ b/src/main/java/bugsbunny/tasks/Deadline.java
@@ -15,8 +15,7 @@ public class Deadline extends Task {
      * @param by Due date-time (inclusive).
      */
     public Deadline(String description, LocalDateTime by) {
-        super(description);
-        this.by = by;
+        this(description, false, by);
     }
 
     /**
@@ -28,6 +27,7 @@ public class Deadline extends Task {
      */
     public Deadline(String description, boolean isDone, LocalDateTime by) {
         super(description, isDone);
+        assert by != null : "End date cannot be null";
         this.by = by;
     }
 

--- a/src/main/java/bugsbunny/tasks/Event.java
+++ b/src/main/java/bugsbunny/tasks/Event.java
@@ -17,9 +17,7 @@ public class Event extends Task {
      * @param to End date-time.
      */
     public Event(String description, LocalDateTime from, LocalDateTime to) {
-        super(description);
-        this.from = from;
-        this.to = to;
+        this(description, false, from, to);
     }
 
     /**
@@ -32,6 +30,8 @@ public class Event extends Task {
      */
     public Event(String description, boolean isDone, LocalDateTime from, LocalDateTime to) {
         super(description, isDone);
+        assert from != null : "Start date cannot be null";
+        assert to != null : "End date cannot be null";
         this.from = from;
         this.to = to;
     }

--- a/src/main/java/bugsbunny/tasks/Task.java
+++ b/src/main/java/bugsbunny/tasks/Task.java
@@ -19,7 +19,7 @@ public abstract class Task {
      * @param description Description of task.
      */
     public Task(String description) {
-        this.description = description;
+        this(description, false);
     }
 
     /**
@@ -29,6 +29,8 @@ public abstract class Task {
      * @param isDone Status completion.
      */
     public Task(String description, boolean isDone) {
+        assert description != null && !description.isBlank()
+                : "Task description must not be null or blank";
         this.description = description;
         this.isDone = isDone;
     }
@@ -60,6 +62,8 @@ public abstract class Task {
      * @throws BugsBunnyException If the line is malformed or has an unknown type.
      */
     public static Task convertFromStorageFormat(String fileTask) throws BugsBunnyException {
+        assert fileTask != null : "File task string should not be null";
+
         String[] parts = fileTask.split(" \\| "); // split on ' | '
 
         if (parts.length < 3) {


### PR DESCRIPTION
The constructor methods for Task, Deadline, Event do not check if the input is null. Similarly, the methods in Parser and Storage do not check if the string arguments are null. This can lead to errors like uncaught exception during run time, which will make debugging difficult.

Assertions help to define assumptions about the program state. Thus enabling assertions can help to catch errors early in development.

Let's,
* add non-null input assertions to the constructor methods for Task, Event and Deadline classes
* assert that the convertFromStorageFormat method in Task takes in a non-null fileTask string
* assert that the save method in Storage takes in a valid TaskList
* assert that the parse method in Command takes in a non-null input string